### PR TITLE
Fixes Depreciation Warning for Python 3.9+

### DIFF
--- a/pix2pixHD/train.py
+++ b/pix2pixHD/train.py
@@ -5,8 +5,11 @@ import torch
 from torch.autograd import Variable
 from collections import OrderedDict
 from subprocess import call
-import fractions
-def lcm(a,b): return abs(a * b)/fractions.gcd(a,b) if a and b else 0
+try:
+    from fractions import gcd
+except ImportError:
+    from math import gcd
+def lcm(a,b): return abs(a * b)/gcd(a,b) if a and b else 0
 
 from options.train_options import TrainOptions
 from data.data_loader import CreateDataLoader


### PR DESCRIPTION
`fractions.gcd()` has been depreciated as of Python 3.9, we must use `math.gcd()`. This will future proof the code for Python versions 3.9+, and added backwards compatibility for Python 3.8 and lower.